### PR TITLE
`findAttribute` is ActionText::TrixAttachment::TAG_NAME agnostic

### DIFF
--- a/src/exports/extensions/find-attribute.ts
+++ b/src/exports/extensions/find-attribute.ts
@@ -5,7 +5,7 @@ export function findAttribute(element: HTMLElement, attribute: string) {
   if (attr) return attr;
 
   const attrs = element
-    .closest("figure[data-trix-attachment]")
+    .closest("[data-trix-attachment]")
     ?.getAttribute("data-trix-attachment");
   if (!attrs) return null;
 


### PR DESCRIPTION
Currently the `findAttribute` function uses a `<figure>` selector during it's second attempt at finding attributes, as this is the default `TAG_NAME` ActionText [uses](https://github.com/rails/rails/blob/main/actiontext/lib/action_text/trix_attachment.rb) during `to_trix_html`. 

While implementing the [tiptap mention extension](https://tiptap.dev/api/nodes/mention), we ran into a challenge where TipTap _really_ wants to treat `figure` nodes as blocks. When trying to display them inline, TipTap was trying to break the figures out using tags like `<p><br class="ProseMirror-trailingBreak"></p>`.

Instead of trying to change TipTap, we opted to change ActionText, as Rails does not care what node delivers the attachment as long as it has the `data-trix-attachment` attribute). And Rails can deliver the attachment via any tag by overriding the `TAG_NAME` constant.

For example: we can specify that ActionText wrap all attachments in a `<span>` tag via `config/initializers/action_text.rb`:

```ruby
module ActionText
  class TrixAttachment
    TAG_NAME = "span"
  end
end
```

There are other places in the editor that use the same `figure[data-trix-attachment]` selector, but they are all within the context of image attachments / galleries.

Currently we have our own custom function to handle this, but you might consider this PR as a more extensible approach.

```javascript
// import { findAttribute } from "rhino-editor/exports/extensions/find-attribute.js";

function findAttribute(element, attribute) {
  const attr = element
    .closest("action-text-attachment")
    ?.getAttribute(attribute);
  if (attr) return attr;

  const attrs = element
    .closest("[data-trix-attachment]")
    ?.getAttribute("data-trix-attachment");
  if (!attrs) return null;

  return JSON.parse(attrs)[attribute];
}
```

