### PR TITLE
fix: remove recursive function call

### DIFF
--- a/.changeset/tricky-peaches-sparkle.md
+++ b/.changeset/tricky-peaches-sparkle.md
@@ -1,0 +1,6 @@
+---
+"rhino-editor": patch
+---
+
+- Fixed a bug where progress bars showed on element with `sgid` on them.
+- Fixed a recursive issue with `setUploadProgress()`

--- a/src/exports/attachment-upload.ts
+++ b/src/exports/attachment-upload.ts
@@ -70,7 +70,6 @@ export class AttachmentUpload implements DirectUploadDelegate {
     }
 
     this.attachment.setUploadProgress(this.currentProgress);
-    this.setUploadProgress();
   }
 
   createBlobUrl(signedId: string, filename: string) {

--- a/src/exports/extensions/attachment.ts
+++ b/src/exports/extensions/attachment.ts
@@ -513,7 +513,7 @@ export const Attachment = Node.create<AttachmentOptions>({
             file-name=${fileName || ""}
             file-size=${String(fileSize || 0)}
             loading-state=${loadingState || LOADING_STATES.notStarted}
-            progress=${String(progress)}
+            progress=${String(sgid ? 100 : progress)}
             contenteditable="false"
             .fileUploadErrorMessage=${this.options.fileUploadErrorMessage}
           >


### PR DESCRIPTION
Originally this recursive function call was there for animating progress bars, but we don't actually animate them anymore because no need to fire tons of changes to the editor. I'll be looking for better ways to animate `<progress>` using CSS as opposed hammering the editor with progress calls.

Fixes #114 

@lylo this should fix your issue.