### PR TITLE
Address whitespace issue with image attachment captions

### DIFF
--- a/tests/rails/app/frontend/entrypoints/application.css
+++ b/tests/rails/app/frontend/entrypoints/application.css
@@ -68,6 +68,9 @@
   font-size: 0.9em;
   line-height: 1.2;
 }
+.trix-content:not(.rhino-editor .trix-content) figcaption {
+  white-space: normal;
+}
 .trix-content .attachment--file {
   color: #333;
   line-height: 1;


### PR DESCRIPTION
The spacing around an image attachment caption is fine when editing rich text, but is over-padded when viewing the rich text content.

Here's the editor view - all good:

<img width="817" alt="Screenshot 2023-09-21 at 17 11 14" src="https://github.com/KonnorRogers/rhino-editor/assets/5447/94f18314-5fd0-4762-9aa1-52a39a97dbcb">

Here's how the caption looked prior to this PR - note the padding:

<img width="582" alt="Screenshot 2023-09-21 at 17 11 08" src="https://github.com/KonnorRogers/rhino-editor/assets/5447/e305373a-f0f8-42f7-a597-7dfaf7e45b77">

Here's how it looks after this patch:

<img width="583" alt="Screenshot 2023-09-21 at 17 10 55" src="https://github.com/KonnorRogers/rhino-editor/assets/5447/c6b78812-04ed-43e6-8a00-3bd3129e8db3">


This is rather odd, and I'm not entirely sure that my patch is the correct solution, but it works for my use case and in the Rhino test editor.

I could do the style override in my own repo but I figured it would be good to have it looking right out of the box. Happy to use this PR for discussion.