### PR TITLE
fix: link clicks are no longer openable by default

### DIFF
--- a/.changeset/fast-turkeys-chew.md
+++ b/.changeset/fast-turkeys-chew.md
@@ -1,0 +1,5 @@
+---
+"rhino-editor": patch
+---
+
+fix: `openOnClick` for links is now set to `false` by default in the editor. This fixes some bugs around editing links and was the original intended behavior.

--- a/src/exports/elements/tip-tap-editor-base.ts
+++ b/src/exports/elements/tip-tap-editor-base.ts
@@ -112,8 +112,8 @@ export class TipTapEditorBase extends BaseElement {
     // We don't use the native strike since it requires configuring ActionText.
     strike: false,
     rhinoLink: {
-      openOnClick: false
-    }
+      openOnClick: false,
+    },
   };
 
   /**

--- a/src/exports/elements/tip-tap-editor-base.ts
+++ b/src/exports/elements/tip-tap-editor-base.ts
@@ -111,6 +111,9 @@ export class TipTapEditorBase extends BaseElement {
   starterKitOptions: Partial<RhinoEditorStarterKitOptions> = {
     // We don't use the native strike since it requires configuring ActionText.
     strike: false,
+    rhinoLink: {
+      openOnClick: false
+    }
   };
 
   /**


### PR DESCRIPTION
Fixes #140 .

Links not being clickable is intended behavior and consistent with Trix.