### PR TITLE
allow light dom editor to be slotted

### DIFF
--- a/.changeset/late-zebras-march.md
+++ b/.changeset/late-zebras-march.md
@@ -1,0 +1,5 @@
+---
+"rhino-editor": patch
+---
+
+fix: link-dialog buttons now have proper hover / focus state.

--- a/.changeset/serious-avocados-act.md
+++ b/.changeset/serious-avocados-act.md
@@ -1,0 +1,5 @@
+---
+"rhino-editor": minor
+---
+
+BREAKING_CHANGE: Allow the light-dom editor to be slotted. Do note, this change may result in a small breaking change for the users relying on the original light-dom structure being `div > div.trix-content`. Most users should not see a difference.

--- a/docs/frontend/styles/_normalize.css
+++ b/docs/frontend/styles/_normalize.css
@@ -1,7 +1,7 @@
 html {
   box-sizing: border-box;
   height: 100%;
-  font-size: 18px;
+  font-size: 16px;
   /* letter-spacing: 0.025em; */
 }
 

--- a/docs/frontend/styles/components/_top_nav.css
+++ b/docs/frontend/styles/components/_top_nav.css
@@ -20,6 +20,8 @@
 
 .top-nav__hamburger__button {
   font-size: 1.75em;
+  display: flex;
+  align-items: center;
 }
 
 .top-nav__hamburger__button::part(base),

--- a/docs/src/_documentation/how_tos/13-add-additional-attributes-onto-the-editor.md
+++ b/docs/src/_documentation/how_tos/13-add-additional-attributes-onto-the-editor.md
@@ -1,0 +1,37 @@
+---
+title: Add Additional Attributes onto the Editor
+permalink: /add-additional-attributes-onto-the-editor/
+---
+
+Sometimes you may want to add additional attributes directly onto the `contenteditable` of RhinoEditor.
+
+The easiest way to do this is by slotting in an editor with the attributes you would like. Here's an example of how we
+could add `aria-*` attributes onto the editor in cases where perhaps the form failed validation.
+
+```erb
+<rhino-editor>
+  <!-- This will get replaced by a new <div>, but will have the attributes copied. -->
+  <div slot="editor" aria-invalid="<%%= object.errors.any? %>" aria-describedby="description-errors">
+  </div>
+</rhino-editor>
+
+<div id="description-errors">
+  <%% if object.errors.any? %>
+    <%%= object.errors.to_s %>
+  <%% end %>
+</div>
+```
+
+This will produce something like the following:
+
+```html
+<rhino-editor>
+  <!-- This will get replaced by a new <div>, but will have the attributes copied. -->
+  <div slot="editor" aria-invalid="true" aria-describedby="description-errors">
+  </div>
+</rhino-editor>
+
+<div id="description-errors">
+  Wow dude. You really messed up. What did you even submit?
+</div>
+```

--- a/src/exports/elements/tip-tap-editor-base.ts
+++ b/src/exports/elements/tip-tap-editor-base.ts
@@ -128,14 +128,14 @@ export class TipTapEditorBase extends BaseElement {
   rebuildEditor() {
     const editors = this.querySelectorAll("[slot='editor']");
 
-    const originalAttributes: Record<string, string> = {}
+    const originalAttributes: Record<string, string> = {};
     if (editors[editors.length - 1]) {
-      ;[...editors[editors.length - 1].attributes].forEach((attr) => {
-        const { nodeName, nodeValue } = attr
+      [...editors[editors.length - 1].attributes].forEach((attr) => {
+        const { nodeName, nodeValue } = attr;
         if (nodeName && nodeValue != null) {
-          originalAttributes[nodeName] = nodeValue
+          originalAttributes[nodeName] = nodeValue;
         }
-      })
+      });
     }
 
     // Make sure we dont render the editor more than once.
@@ -154,10 +154,10 @@ export class TipTapEditorBase extends BaseElement {
     this.editorElement = this.querySelector(".ProseMirror");
 
     Object.entries(originalAttributes)?.forEach(([attrName, attrValue]) => {
-      this.editorElement?.setAttribute(attrName, attrValue)
-    })
+      this.editorElement?.setAttribute(attrName, attrValue);
+    });
 
-    this.editorElement?.setAttribute("slot", "editor")
+    this.editorElement?.setAttribute("slot", "editor");
     this.editorElement?.classList.add("trix-content");
     this.editorElement?.setAttribute("tabindex", "0");
     this.editorElement?.setAttribute("role", "textbox");

--- a/src/exports/elements/tip-tap-editor-base.ts
+++ b/src/exports/elements/tip-tap-editor-base.ts
@@ -124,17 +124,17 @@ export class TipTapEditorBase extends BaseElement {
   /**
    * @internal
    */
-   __initialAttributes: Record<string, string> = {}
+  __initialAttributes: Record<string, string> = {};
 
   /**
    * @internal
    */
-   __hasRendered: boolean = false
+  __hasRendered: boolean = false;
 
-   __getInitialAttributes () {
-    if (this.__hasRendered) return
+  __getInitialAttributes() {
+    if (this.__hasRendered) return;
 
-    const slottedEditor = this.slottedEditor
+    const slottedEditor = this.slottedEditor;
     if (slottedEditor) {
       this.__initialAttributes = {};
       [...slottedEditor.attributes].forEach((attr) => {
@@ -145,8 +145,8 @@ export class TipTapEditorBase extends BaseElement {
       });
     }
 
-    this.__hasRendered = true
-   }
+    this.__hasRendered = true;
+  }
 
   /**
    * Reset mechanism. This is called on first connect, and called anytime extensions,
@@ -155,7 +155,7 @@ export class TipTapEditorBase extends BaseElement {
   rebuildEditor() {
     const editors = this.querySelectorAll("[slot='editor']");
 
-    this.__getInitialAttributes()
+    this.__getInitialAttributes();
 
     // Make sure we dont render the editor more than once.
     if (this.editor) this.editor.destroy();
@@ -170,15 +170,17 @@ export class TipTapEditorBase extends BaseElement {
 
     this.__bindEditorListeners();
 
-    this.editorElement = this.querySelector(".ProseMirror")
+    this.editorElement = this.querySelector(".ProseMirror");
 
-    Object.entries(this.__initialAttributes)?.forEach(([attrName, attrValue]) => {
-      if (attrName === "class") {
-        this.editorElement?.classList.add(...attrValue.split(" "))
-        return
-      }
-      this.editorElement?.setAttribute(attrName, attrValue);
-    });
+    Object.entries(this.__initialAttributes)?.forEach(
+      ([attrName, attrValue]) => {
+        if (attrName === "class") {
+          this.editorElement?.classList.add(...attrValue.split(" "));
+          return;
+        }
+        this.editorElement?.setAttribute(attrName, attrValue);
+      },
+    );
 
     this.editorElement?.setAttribute("slot", "editor");
     this.editorElement?.classList.add("trix-content");
@@ -480,7 +482,6 @@ export class TipTapEditorBase extends BaseElement {
   renderDialog() {}
 
   render(): TemplateResult {
-
     return html`
       ${this.renderToolbar()}
       <div class="editor-wrapper" part="editor-wrapper">

--- a/src/exports/elements/tip-tap-editor-base.ts
+++ b/src/exports/elements/tip-tap-editor-base.ts
@@ -167,9 +167,7 @@ export class TipTapEditorBase extends BaseElement {
   }
 
   protected willUpdate(
-    changedProperties:
-      | PropertyValueMap<this & { class: string }>
-      | Map<PropertyKey, unknown>,
+    changedProperties: PropertyValueMap<any> | Map<PropertyKey, unknown>,
   ): void {
     if (changedProperties.has("class")) {
       this.classList.add("rhino-editor");
@@ -185,17 +183,17 @@ export class TipTapEditorBase extends BaseElement {
   protected updated(
     changedProperties: PropertyValueMap<any> | Map<PropertyKey, unknown>,
   ): void {
-    // if (
-    //   changedProperties.has("extensions") ||
-    //   changedProperties.has("starterKitOptions") ||
-    //   changedProperties.has("translations")
-    // ) {
-    //   this.rebuildEditor();
-    // }
-    //
-    // if (changedProperties.has("readonly")) {
-    //   this.editor?.setEditable(!this.readonly);
-    // }
+    if (changedProperties.has("readonly")) {
+      this.editor?.setEditable(!this.readonly);
+    }
+
+    if (
+      changedProperties.has("extensions") ||
+      changedProperties.has("starterKitOptions") ||
+      changedProperties.has("translations")
+    ) {
+      this.rebuildEditor();
+    }
 
     super.updated(changedProperties);
   }

--- a/src/exports/elements/tip-tap-editor.ts
+++ b/src/exports/elements/tip-tap-editor.ts
@@ -1109,14 +1109,14 @@ export class TipTapEditor extends TipTapEditorBase {
         />
         <div class="link-dialog__buttons" part="link-dialog__buttons">
           <button
-            class="link-dialog__button"
+            class="rhino-toolbar-button link-dialog__button"
             part="link-dialog__button link-dialog__button--link"
             @click=${this.addLink}
           >
             ${this.translations.linkDialogLink}
           </button>
           <button
-            class="link-dialog__button"
+            class="rhino-toolbar-button link-dialog__button"
             part="link-dialog__button link-dialog__button--unlink"
             @click=${() => {
               this.editor

--- a/src/exports/styles/editor.js
+++ b/src/exports/styles/editor.js
@@ -130,7 +130,7 @@ export default css`
     border-bottom-left-radius: 0px;
   }
 
-  .toolbar::part(base):is(:focus-within) {
+  .toolbar::part(base):is(:focus-visible, :focus-within) {
     border-color: var(--rhino-button-active-border-color);
     outline: transparent;
   }
@@ -177,7 +177,6 @@ export default css`
 
   .link-dialog__input:is(:focus) {
     outline: transparent;
-    box-shadow: var(--rhino-focus-ring);
     border-color: var(--rhino-button-active-border-color);
   }
 
@@ -188,7 +187,7 @@ export default css`
     box-shadow: none;
   }
 
-  .link-dialog__button {
+  .rhino-toolbar-button.link-dialog__button {
     padding: 0.4em 0.6em;
     border: 1px solid var(--rhino-button-border-color);
     border-radius: var(--rhino-border-radius);

--- a/tests/rails/app/views/posts/_form.html.erb
+++ b/tests/rails/app/views/posts/_form.html.erb
@@ -36,6 +36,8 @@
         <%# <button slot="toolbar-end" tabindex="-1" type="button" data-role="toolbar-item">Embed</button> %>
         <%# <button slot="toolbar-end" tabindex="-1" type="button" data-role="toolbar-item">EmbedTwo</button> %>
         <button slot="before-undo-button" tabindex="-1" type="button" data-role="toolbar-item" data-controller="embed">Embed</button>
+
+        <div slot="editor" data-class="my-class"></div>
       </rhino-editor>
     </section>
 
@@ -53,13 +55,6 @@
           name: "trix-tip-tap-mirror",
           value: params[:raw] ? post.trix_body : (post.trix_body.try(:to_trix_html) || post.trix_body)
         %>
-        <rhino-editor
-          style="margin-top: 2rem;"
-          input="trix-tip-tap-mirror"
-          data-blob-url-template="<%= rails_service_blob_url(":signed_id", ":filename") %>"
-          data-direct-upload-url="<%= rails_direct_uploads_url %>"
-          data-controller="tip-tap-mirror"
-        ></rhino-editor>
       </div>
     </section>
   </div>

--- a/tests/rails/app/views/posts/_form.html.erb
+++ b/tests/rails/app/views/posts/_form.html.erb
@@ -37,7 +37,7 @@
         <%# <button slot="toolbar-end" tabindex="-1" type="button" data-role="toolbar-item">EmbedTwo</button> %>
         <button slot="before-undo-button" tabindex="-1" type="button" data-role="toolbar-item" data-controller="embed">Embed</button>
 
-        <div slot="editor" data-class="my-class"></div>
+        <div slot="editor" aria-invalid="true" class="my-class"></div>
       </rhino-editor>
     </section>
 

--- a/tests/rails/app/views/posts/_form.html.erb
+++ b/tests/rails/app/views/posts/_form.html.erb
@@ -55,6 +55,13 @@
           name: "trix-tip-tap-mirror",
           value: params[:raw] ? post.trix_body : (post.trix_body.try(:to_trix_html) || post.trix_body)
         %>
+        <rhino-editor
+          style="margin-top: 2rem;"
+          input="trix-tip-tap-mirror"
+          data-blob-url-template="<%= rails_service_blob_url(":signed_id", ":filename") %>"
+          data-direct-upload-url="<%= rails_direct_uploads_url %>"
+          data-controller="tip-tap-mirror"
+        ></rhino-editor>
       </div>
     </section>
   </div>

--- a/tests/unit/light-dom-render.test.js
+++ b/tests/unit/light-dom-render.test.js
@@ -1,0 +1,22 @@
+// @ts-check
+import { TipTapEditor } from "../../exports/elements/tip-tap-editor.js"
+import { fixture, assert, aTimeout } from "@open-wc/testing"
+import { html } from "lit"
+
+test("Should only render a textbox once", async () => {
+  /** @type {TipTapEditor} */
+  const editor = await fixture(html`<rhino-editor aria-describedby="errors" aria-invalid="true" class="my-class"></rhino-editor>`)
+
+  TipTapEditor.define()
+  await aTimeout(1)
+
+  assert.equal(editor.querySelectorAll("[role='textbox']").length, 1)
+
+  // The attributes we put on the editor should not get overwritten when the rendering process happens.
+  assert.equal(editor.getAttribute("aria-describedby"), "errors")
+  assert.equal(editor.getAttribute("aria-invalid"), "true")
+
+  // Make sure classes don't get overwritten
+  assert(editor.classList.contains("my-class"))
+})
+

--- a/tests/unit/light-dom-render.test.js
+++ b/tests/unit/light-dom-render.test.js
@@ -18,5 +18,8 @@ test("Should only render a textbox once", async () => {
 
   // Make sure classes don't get overwritten
   assert(editor.classList.contains("my-class"))
+  assert(editor.classList.contains("trix-content"))
+  assert(editor.classList.contains("ProseMirror"))
+  assert(editor.classList.contains("tiptap"))
 })
 

--- a/tests/unit/light-dom-render.test.js
+++ b/tests/unit/light-dom-render.test.js
@@ -5,21 +5,24 @@ import { html } from "lit"
 
 test("Should only render a textbox once", async () => {
   /** @type {TipTapEditor} */
-  const editor = await fixture(html`<rhino-editor aria-describedby="errors" aria-invalid="true" class="my-class"></rhino-editor>`)
+  const rhinoEditor = await fixture(html`<rhino-editor>
+    <div slot="editor" aria-describedby="errors" aria-invalid="true" class="my-class"></div>
+  </rhino-editor>`)
 
   TipTapEditor.define()
-  await aTimeout(1)
+  await aTimeout(100)
 
-  assert.equal(editor.querySelectorAll("[role='textbox']").length, 1)
+  assert.equal(rhinoEditor.querySelectorAll("[role='textbox']").length, 1)
+
+  const editor = rhinoEditor.querySelector(".trix-content")
 
   // The attributes we put on the editor should not get overwritten when the rendering process happens.
-  assert.equal(editor.getAttribute("aria-describedby"), "errors")
-  assert.equal(editor.getAttribute("aria-invalid"), "true")
+  assert.equal(editor?.getAttribute("aria-describedby"), "errors")
+  assert.equal(editor?.getAttribute("aria-invalid"), "true")
 
   // Make sure classes don't get overwritten
-  assert(editor.classList.contains("my-class"))
-  assert(editor.classList.contains("trix-content"))
-  assert(editor.classList.contains("ProseMirror"))
-  assert(editor.classList.contains("tiptap"))
+  assert(editor?.classList.contains("my-class"))
+  assert(editor?.classList.contains("trix-content"))
+  assert(editor?.classList.contains("tiptap"))
 })
 

--- a/tests/unit/light-dom-render.test.js
+++ b/tests/unit/light-dom-render.test.js
@@ -1,15 +1,13 @@
 // @ts-check
-import { TipTapEditor } from "../../exports/elements/tip-tap-editor.js"
+import "rhino-editor"
 import { fixture, assert, aTimeout } from "@open-wc/testing"
 import { html } from "lit"
 
 test("Should only render a textbox once", async () => {
-  /** @type {TipTapEditor} */
   const rhinoEditor = await fixture(html`<rhino-editor>
     <div slot="editor" aria-describedby="errors" aria-invalid="true" class="my-class"></div>
   </rhino-editor>`)
 
-  TipTapEditor.define()
   await aTimeout(100)
 
   assert.equal(rhinoEditor.querySelectorAll("[role='textbox']").length, 1)
@@ -23,6 +21,7 @@ test("Should only render a textbox once", async () => {
   // Make sure classes don't get overwritten
   assert(editor?.classList.contains("my-class"))
   assert(editor?.classList.contains("trix-content"))
+  console.log(editor.outerHTML)
   assert(editor?.classList.contains("tiptap"))
 })
 

--- a/tests/unit/serializer.test.js
+++ b/tests/unit/serializer.test.js
@@ -16,7 +16,7 @@ test("It should properly update the input element when the serializer changes", 
   const input = div.querySelector("input")
 
   assert.equal(rhinoEditor.serializer, "html")
-  assert.equal(input.value, "<p></p>")
+  assert.equal(input.value, "")
 
   rhinoEditor.serializer = "json"
 

--- a/tests/unit/serializer.test.js
+++ b/tests/unit/serializer.test.js
@@ -10,6 +10,8 @@ test("It should properly update the input element when the serializer changes", 
     <rhino-editor input="input"></rhino-editor>
   </div>`)
 
+  await aTimeout(0)
+
   const rhinoEditor = div.querySelector("rhino-editor")
   const input = div.querySelector("input")
 


### PR DESCRIPTION
There's an annoying issue where calling `new Editor(element)` always injects the new ProseMirror element inside of the wrapping element so you end up with this:

```html
<div slot="editor">
  <div class="tiptap"></div>
</div>
```

This PR works around that and fixes the DOM, but it means wiping out state of the previous element (which I think is fine)

This PR enables the following:

```html
<rhino-editor>
  <div slot="editor" aria-invalid="true" aria-describedby="description-errors"></div>
</rhino-editor>
```

The attributes will then be copied into the new TipTap instance and will produce something that looks like this:

```html
<div slot="editor" aria-invalid="true" aria-describedby="description-errors" class="tiptap trix-content ProseMirror" tabindex="0" contenteditable="true"></div>
```

**Note:** The original `<div>` gets destroyed and a new one is created with the attributes being cloned. The reason is that if we don't do this we end up with cached editors from Turbo.

For a very small subset of users this may be a very minor breaking change affecting styling.

```html
<rhino-editor>
  <div slot="editor" style="position: relative;">
    <div class="ProseMirror tiptap trix-content" tabindex="0" role="textbox" contenteditable="true"></div>
  </div>
</rhino-editor>
```

Now looks like the following:

```html
<rhino-editor>
  <div slot="editor" class="ProseMirror tiptap trix-content" tabindex="0" role="textbox" contenteditable="true"></div>
</rhino-editor>
```

Fixes #141 

TODO:

- [x] - Simple smoke tests
- [x] - Documentation