### PR TITLE
fix custom extensions not loading because of eager rebuilds

### DIFF
--- a/.changeset/itchy-wombats-hide.md
+++ b/.changeset/itchy-wombats-hide.md
@@ -1,0 +1,5 @@
+---
+"rhino-editor": patch
+---
+
+Fixed a bug in the update lifecycles of RhinoEditor causing rebuilds to happen too frequently

--- a/src/exports/elements/tip-tap-editor-base.ts
+++ b/src/exports/elements/tip-tap-editor-base.ts
@@ -46,7 +46,10 @@ export type RhinoEditorStarterKitOptions = StarterKitOptions &
     decreaseIndentation: boolean;
   };
 
-const debounce = <T extends ((...args: unknown[]) => unknown)>(mainFunction: T, delay: number = 0) => {
+const debounce = <T extends (...args: unknown[]) => unknown>(
+  mainFunction: T,
+  delay: number = 0,
+) => {
   // Declare a variable called 'timer' to store the timer ID
   let timer: ReturnType<typeof setTimeout>;
 
@@ -138,11 +141,11 @@ export class TipTapEditorBase extends BaseElement {
   extensions: EditorOptions["extensions"] = [];
 
   /**
-    * Debounced editor rebuilder for cases where you may be calling `rebuildEditor` in the same event loop.
-    */
+   * Debounced editor rebuilder for cases where you may be calling `rebuildEditor` in the same event loop.
+   */
   debouncedRebuildEditor = debounce(() => {
-    this.rebuildEditor()
-  }, 0)
+    this.rebuildEditor();
+  }, 0);
 
   /**
    * @internal

--- a/src/exports/elements/tip-tap-editor-base.ts
+++ b/src/exports/elements/tip-tap-editor-base.ts
@@ -328,7 +328,7 @@ export class TipTapEditorBase extends BaseElement {
       changedProperties.has("starterKitOptions") ||
       changedProperties.has("translations")
     ) {
-      this.rebuildEditor()
+      this.rebuildEditor();
     }
 
     if (changedProperties.has("serializer")) {

--- a/src/exports/elements/tip-tap-editor-base.ts
+++ b/src/exports/elements/tip-tap-editor-base.ts
@@ -46,25 +46,6 @@ export type RhinoEditorStarterKitOptions = StarterKitOptions &
     decreaseIndentation: boolean;
   };
 
-const debounce = <T extends (...args: unknown[]) => unknown>(
-  mainFunction: T,
-  delay: number = 0,
-) => {
-  // Declare a variable called 'timer' to store the timer ID
-  let timer: ReturnType<typeof setTimeout>;
-
-  // Return an anonymous function that takes in any number of arguments
-  return function (...args: Parameters<T>) {
-    // Clear the previous timer to prevent the execution of 'mainFunction'
-    clearTimeout(timer);
-
-    // Set a new timer that will execute 'mainFunction' after the specified delay
-    timer = setTimeout(() => {
-      mainFunction(...args);
-    }, delay);
-  };
-};
-
 export class TipTapEditorBase extends BaseElement {
   // Static
 
@@ -139,13 +120,6 @@ export class TipTapEditorBase extends BaseElement {
    * This will be concatenated onto RhinoStarterKit and StarterKit extensions.
    */
   extensions: EditorOptions["extensions"] = [];
-
-  /**
-   * Debounced editor rebuilder for cases where you may be calling `rebuildEditor` in the same event loop.
-   */
-  debouncedRebuildEditor = debounce(() => {
-    this.rebuildEditor();
-  }, 0);
 
   /**
    * @internal
@@ -338,10 +312,6 @@ export class TipTapEditorBase extends BaseElement {
       this.classList.add("rhino-editor");
     }
 
-    if (changedProperties.has("serializer")) {
-      this.updateInputElementValue();
-    }
-
     super.willUpdate(changedProperties);
   }
 
@@ -354,9 +324,15 @@ export class TipTapEditorBase extends BaseElement {
 
     if (
       changedProperties.has("extensions") ||
-      changedProperties.has("starterKitOptions")
+      changedProperties.has("serializer") ||
+      changedProperties.has("starterKitOptions") ||
+      changedProperties.has("translations")
     ) {
-      this.debouncedRebuildEditor();
+      this.rebuildEditor()
+    }
+
+    if (changedProperties.has("serializer")) {
+      this.updateInputElementValue();
     }
 
     super.updated(changedProperties);

--- a/src/exports/elements/tip-tap-editor.ts
+++ b/src/exports/elements/tip-tap-editor.ts
@@ -149,6 +149,7 @@ export class TipTapEditor extends TipTapEditorBase {
   }
 
   protected updated(changedProperties: PropertyValues<this>): void {
+    const returnValue = super.updated(changedProperties);
     if (changedProperties.has("translations")) {
       const { rhinoAttachment, rhinoPlaceholder } = this.starterKitOptions;
       let shouldRebuild = Boolean(rhinoAttachment || rhinoPlaceholder);
@@ -165,11 +166,11 @@ export class TipTapEditor extends TipTapEditorBase {
       }
 
       if (shouldRebuild) {
-        this.debouncedRebuildEditor();
+        this.rebuildEditor();
       }
     }
 
-    return super.willUpdate(changedProperties);
+    return returnValue
   }
 
   /**

--- a/src/exports/elements/tip-tap-editor.ts
+++ b/src/exports/elements/tip-tap-editor.ts
@@ -165,7 +165,7 @@ export class TipTapEditor extends TipTapEditorBase {
       }
 
       if (shouldRebuild) {
-        this.debouncedRebuildEditor()
+        this.debouncedRebuildEditor();
       }
     }
 

--- a/src/exports/elements/tip-tap-editor.ts
+++ b/src/exports/elements/tip-tap-editor.ts
@@ -170,7 +170,7 @@ export class TipTapEditor extends TipTapEditorBase {
       }
     }
 
-    return returnValue
+    return returnValue;
   }
 
   /**

--- a/src/exports/elements/tip-tap-editor.ts
+++ b/src/exports/elements/tip-tap-editor.ts
@@ -148,7 +148,7 @@ export class TipTapEditor extends TipTapEditorBase {
     this.addEventListener("keydown", this.handleKeyboardDialogToggle);
   }
 
-  protected willUpdate(changedProperties: PropertyValues<this>): void {
+  protected updated(changedProperties: PropertyValues<this>): void {
     if (changedProperties.has("translations")) {
       const { rhinoAttachment, rhinoPlaceholder } = this.starterKitOptions;
       let shouldRebuild = Boolean(rhinoAttachment || rhinoPlaceholder);
@@ -165,9 +165,10 @@ export class TipTapEditor extends TipTapEditorBase {
       }
 
       if (shouldRebuild) {
-        this.rebuildEditor();
+        this.debouncedRebuildEditor()
       }
     }
+
     return super.willUpdate(changedProperties);
   }
 


### PR DESCRIPTION
A change in detecting placeholders were causing rebuilds to happen too quickly. We now have a `debouncedRebuildEditor()` that waits until the next event loop to rebuild so we dont call `rebuildEditor()` too frequently.