### PR TITLE
Fix link to Setup tutorial

### DIFF
--- a/docs/src/_documentation/how_tos/05-change-the-placeholder.md
+++ b/docs/src/_documentation/how_tos/05-change-the-placeholder.md
@@ -3,7 +3,7 @@ title: Change the placeholder
 permalink: /how-tos/change-the-placeholder/
 ---
 
-Perhaps you read the [Setup](tutorials/setup) sections that describe modifying the
+Perhaps you read the [Setup](/tutorials/setup) sections that describe modifying the
 default behavior of the `starterKitOptions`. While you could do the following to modify the placeholder:
 
 <%= render Syntax.new("js") do %>


### PR DESCRIPTION
![image](https://github.com/KonnorRogers/rhino-editor/assets/80279872/df55b478-974c-4262-9f40-74e483423660)

This link is broken on https://rhino-editor.vercel.app/how-tos/change-the-placeholder/, it's pointing to `/how-tos/change-the-placeholder/tutorials/setup` when it should point to `/tutorials/setup/`