### PR TITLE
Link handling tweaks

### DIFF
--- a/.changeset/violet-queens-perform.md
+++ b/.changeset/violet-queens-perform.md
@@ -1,0 +1,5 @@
+---
+"rhino-editor": patch
+---
+
+Fix the UX of link insertions

--- a/src/exports/elements/tip-tap-editor.ts
+++ b/src/exports/elements/tip-tap-editor.ts
@@ -303,6 +303,7 @@ export class TipTapEditor extends TipTapEditorBase {
 
   closeLinkDialog(): void {
     this.linkDialogExpanded = false;
+    this.editor.commands.focus();
   }
 
   showLinkDialog(): void {

--- a/src/exports/elements/tip-tap-editor.ts
+++ b/src/exports/elements/tip-tap-editor.ts
@@ -351,6 +351,7 @@ export class TipTapEditor extends TipTapEditorBase {
     } catch (error) {
       inputElement.setCustomValidity("Not a valid URL");
       this.__invalidLink__ = true;
+      inputElement.reportValidity();
       return;
     }
 

--- a/src/exports/elements/tip-tap-editor.ts
+++ b/src/exports/elements/tip-tap-editor.ts
@@ -357,18 +357,19 @@ export class TipTapEditor extends TipTapEditorBase {
     if (href) {
       this.closeLinkDialog();
       inputElement.value = "";
+
+      if (this.editor.state.selection.empty && !this.editor.getAttributes('link').href) {
+        const from = this.editor.state.selection.anchor;
+        this.editor.commands.insertContent(href);
+        const to = this.editor.state.selection.anchor;
+        this.editor.commands.setTextSelection({from, to});
+      }
+
       const chain = this.editor
         ?.chain()
         .extendMarkRange("link")
-        .setLink({ href });
-
-      if (chain && this.editor?.state.selection.empty) {
-        chain.insertContent(href);
-      }
-
-      if (chain) {
-        chain.run();
-      }
+        .setLink({ href })
+        .run();
     }
   }
 


### PR DESCRIPTION
Here are a few tweaks for your perusal. Feel free to bring in what you think is appropriate in whatever way you feel is appropriate!

---

https://github.com/KonnorRogers/rhino-editor/commit/4a95e512b8a9359651a571edc417fec8f482691a
**Focus the editor when link dialog is closed.**
This is especially useful when the ESC key is hit. Without this, the link dialog disappears, you expect to be able to continue editing, but the editor does not have focus. Now it does!

---

https://github.com/KonnorRogers/rhino-editor/commit/fc4e98986063bd17f549c7b255e591ea6dca6110
**Update addLink behavior to handle editing link without a full selection.**
When your cursor is within a node of linked text and the link dialog is opened, the intention is almost always to edit the link for the full node rather than insert a new link in place of the text for which the cursor is sitting.

Here's how this interaction worked before:

https://share.cleanshot.com/1NYHrBxP

With this change, editing a link when the cursor is within a linked node will edit the link for the entire linked text rather than replacing or inserting the new link in place of or in the midst of the linked node text.

Here is the change in action:

https://share.cleanshot.com/gLjDmjwN

---

https://github.com/KonnorRogers/rhino-editor/commit/f7ad92bdf14f8c89900c7544545f8139c5b93f70
**Show invalid URL message when link validity is broken.**
Prior to this the text field would turn red, but the "Not a valid URL" message did not appear to the user.