### PR TITLE
Fix off by one issue with attachments and paste issues

### DIFF
--- a/.changeset/honest-pears-repair.md
+++ b/.changeset/honest-pears-repair.md
@@ -1,0 +1,5 @@
+---
+"rhino-editor": patch
+---
+
+Fix issues with paste extensions

--- a/.changeset/new-donkeys-greet.md
+++ b/.changeset/new-donkeys-greet.md
@@ -1,0 +1,5 @@
+---
+"rhino-editor": patch
+---
+
+Fix issues with attachment pasting

--- a/src/exports/extensions/attachment.ts
+++ b/src/exports/extensions/attachment.ts
@@ -1088,19 +1088,21 @@ function handleAttachment(
       );
     }
 
+    // The following checks fix some "off by 1" issues. I _think_ these are the only nodes we need to check. May need a more robust check if this continues to be an issue.
     let from = currSelection.from;
     const prevNode = state.doc.resolve(from - 1);
     const parentNode = prevNode.parent;
 
-    if (parentNode) {
-      const parentNodeName = parentNode.type.name;
+    if (parentNode && parentNode.type.name === "doc") {
+      from -= 1;
+    } else {
+      const closestParagraph = findParentNodeOfTypeClosestToPos(
+        prevNode,
+        schema.nodes["paragraph"]
+      )
 
-      if (parentNodeName === "doc") {
-        from -= 1;
-      }
-
-      if (parentNodeName === "paragraph" && parentNode.textContent === "") {
-        from -= 1;
+      if (closestParagraph && closestParagraph.node.textContent === "") {
+        from -= 1
       }
     }
 

--- a/src/exports/extensions/attachment.ts
+++ b/src/exports/extensions/attachment.ts
@@ -1089,7 +1089,7 @@ function handleAttachment(
     }
 
     // The following checks fix some "off by 1" issues. I _think_ these are the only nodes we need to check. May need a more robust check if this continues to be an issue.
-    // https://github.com/KonnorRogers/rhino-editor/issues/256
+    // https://github.com/KonnorRogers/rhino-editor/issues/254
     let from = currSelection.from;
     const prevNode = state.doc.resolve(from - 1);
     const parentNode = prevNode.parent;

--- a/src/exports/extensions/attachment.ts
+++ b/src/exports/extensions/attachment.ts
@@ -1088,7 +1088,23 @@ function handleAttachment(
       );
     }
 
-    tr.replaceWith(currSelection.from - 1, currSelection.to, [
+    let from = currSelection.from
+    const prevNode = state.doc.resolve(from - 1);
+    const parentNode = prevNode.parent
+
+    if (parentNode) {
+      const parentNodeName = parentNode.type.name
+
+      if (parentNodeName === "doc") {
+        from -= 1
+      }
+
+      if (parentNodeName === "paragraph" && parentNode.textContent === "") {
+        from -= 1
+      }
+    }
+
+    tr.replaceWith(from, currSelection.to, [
       ...attachmentNodes,
       schema.nodes.paragraph.create(),
     ]);

--- a/src/exports/extensions/attachment.ts
+++ b/src/exports/extensions/attachment.ts
@@ -1088,19 +1088,19 @@ function handleAttachment(
       );
     }
 
-    let from = currSelection.from
+    let from = currSelection.from;
     const prevNode = state.doc.resolve(from - 1);
-    const parentNode = prevNode.parent
+    const parentNode = prevNode.parent;
 
     if (parentNode) {
-      const parentNodeName = parentNode.type.name
+      const parentNodeName = parentNode.type.name;
 
       if (parentNodeName === "doc") {
-        from -= 1
+        from -= 1;
       }
 
       if (parentNodeName === "paragraph" && parentNode.textContent === "") {
-        from -= 1
+        from -= 1;
       }
     }
 

--- a/src/exports/extensions/attachment.ts
+++ b/src/exports/extensions/attachment.ts
@@ -1089,6 +1089,7 @@ function handleAttachment(
     }
 
     // The following checks fix some "off by 1" issues. I _think_ these are the only nodes we need to check. May need a more robust check if this continues to be an issue.
+    // https://github.com/KonnorRogers/rhino-editor/issues/256
     let from = currSelection.from;
     const prevNode = state.doc.resolve(from - 1);
     const parentNode = prevNode.parent;

--- a/src/exports/extensions/attachment.ts
+++ b/src/exports/extensions/attachment.ts
@@ -1098,11 +1098,11 @@ function handleAttachment(
     } else {
       const closestParagraph = findParentNodeOfTypeClosestToPos(
         prevNode,
-        schema.nodes["paragraph"]
-      )
+        schema.nodes["paragraph"],
+      );
 
       if (closestParagraph && closestParagraph.node.textContent === "") {
-        from -= 1
+        from -= 1;
       }
     }
 

--- a/src/exports/extensions/paste.ts
+++ b/src/exports/extensions/paste.ts
@@ -5,20 +5,31 @@ export interface PasteOptions {}
 
 // Super simple plugin that dispatches a paste event. This is convenient way to make this hard to override.
 export function Paste() {
+  const handledEvents = new WeakMap()
+
   return new Plugin({
     key: new PluginKey("rhino-paste-event"),
     props: {
       handlePaste(view, event) {
         const { clipboardData } = event;
 
+        // We always return false to allow other extensions to actually handle the paste via props.
+
         if (event.defaultPrevented) {
-          return true;
+          return false;
         }
+
+        if (handledEvents.has(event)) {
+          // This event has already processed. This prevents emitting the event twice.
+          return false
+        }
+
+        handledEvents.set(event, null)
 
         const rhinoPasteEvent = new RhinoPasteEvent(clipboardData);
         view.dom.dispatchEvent(rhinoPasteEvent);
 
-        return true;
+        return false;
 
         // @TODO: Future enhancements for pasting
         // https://github.com/basecamp/trix/blob/fda14c5ae88a0821cf8999a53dcb3572b4172cf0/src/trix/controllers/level_0_input_controller.js#L39

--- a/src/exports/extensions/paste.ts
+++ b/src/exports/extensions/paste.ts
@@ -5,7 +5,7 @@ export interface PasteOptions {}
 
 // Super simple plugin that dispatches a paste event. This is convenient way to make this hard to override.
 export function Paste() {
-  const handledEvents = new WeakMap()
+  const handledEvents = new WeakMap();
 
   return new Plugin({
     key: new PluginKey("rhino-paste-event"),
@@ -21,10 +21,10 @@ export function Paste() {
 
         if (handledEvents.has(event)) {
           // This event has already processed. This prevents emitting the event twice.
-          return false
+          return false;
         }
 
-        handledEvents.set(event, null)
+        handledEvents.set(event, null);
 
         const rhinoPasteEvent = new RhinoPasteEvent(clipboardData);
         view.dom.dispatchEvent(rhinoPasteEvent);


### PR DESCRIPTION
Fixes #254 

@bjhess I can't fully test this, but it should fix #257 with your paste issues.

Paste now maintains a "WeakMap" of already handled paste events to prevent double paste event, but returns `false` now instead of `true` which should allow extensions to properly handle paste. 