### PR TITLE
Syntax highlighting documentation updates.

### DIFF
--- a/docs/frontend/javascript/entrypoints/syntax-highlighting.js
+++ b/docs/frontend/javascript/entrypoints/syntax-highlighting.js
@@ -6,6 +6,7 @@ import {common, createLowlight} from 'lowlight'
 import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight'
 
 // This will important for storing fully syntax highlighted code.
+import he from 'he'
 import {toHtml} from 'hast-util-to-html'
 
 const lowlight = createLowlight(common)
@@ -24,6 +25,11 @@ function extendRhinoEditor (event) {
 
   if (rhinoEditor == null) return
 
+  const form = rhinoEditor.closest('form')
+  if (form) {
+    preProcessRhinoFormInputs(form)
+  }
+
   rhinoEditor.starterKitOptions = {
     ...rhinoEditor.starterKitOptions,
     // We disable codeBlock from the starterkit to be able to use CodeBlockLowlight's extension.
@@ -35,7 +41,36 @@ function extendRhinoEditor (event) {
   rhinoEditor.rebuildEditor()
 }
 
-document.addEventListener("rhino-before-initialize", extendRhinoEditor)
+document.addEventListener("rhino-before-initialize", extendRhinoEditor, { once: true })
+
+function preProcessRhinoFormInputs(form) {
+  const rhinoInputs = [...form.elements].filter((el) => el.classList.contains("rhino-editor-input"))
+  rhinoInputs.forEach((inputElement) => {
+    inputElement.value = stripHljsSpans(inputElement.value)
+  })
+}
+
+// When editing existing code blocks, strip the highlighting spans that wrap the code
+// blocks. This allows CodeBlockLowlight to then properly re-parse the code blocks
+// for highlighting. Without this, the spans do appear in the editor's highlighted
+// code blocks, but some newlines are missing. The missing newlines will be
+// when they are at the end of a line with only whitespace after them. Those
+// newlines get lost in processing if these spans are not first stripped.
+function stripHljsSpans(content) {
+  const tempDoc = new DOMParser().parseFromString(content, 'text/html')
+
+  tempDoc.querySelectorAll('pre > code').forEach(codeEl => {
+    const spans = codeEl.querySelectorAll('span[class^="hljs-"]')
+
+    spans.forEach(span => {
+      const textNode = document.createTextNode(span.textContent)
+      span.parentNode.replaceChild(textNode, span)
+    })
+  })
+
+  return tempDoc.body.innerHTML
+}
+
 
 // This next part is specifically for storing fully syntax highlighted markup in your database.
 //
@@ -44,16 +79,16 @@ document.addEventListener("rhino-before-initialize", extendRhinoEditor)
 const highlightCodeblocks = (content) => {
   const doc = new DOMParser().parseFromString(content, 'text/html');
 
-  // If it has the "[has-highlighted]" attribute attached, we know it has already been syntax highlighted.
-  // This will get stripped from the editor.
-  doc.querySelectorAll('pre > code:not([has-highlighted])').forEach((el) => {
+  doc.querySelectorAll('pre > code').forEach((el) => {
     const languageClass = [...el.classList].find(cls => cls.startsWith('language-'));
     const language = languageClass ? languageClass.replace('language-', '') : null;
-    const html = language ?
-      toHtml(lowlight.highlight(language, el.innerHTML).children) :
-      toHtml(lowlight.highlightAuto(el.innerHTML).children);
 
-    el.setAttribute("has-highlighted", "");
+    // Decode the content before re-parsing so that we do not double-encode any HTML entities.
+    const decodedContent = he.decode(el.innerHTML)
+    const html = language ?
+      toHtml(lowlight.highlight(language, decodedContent).children) :
+      toHtml(lowlight.highlightAuto(decodedContent).children);
+
     el.innerHTML = html;
   });
 

--- a/docs/src/_documentation/how_tos/10-syntax-highlighting.md
+++ b/docs/src/_documentation/how_tos/10-syntax-highlighting.md
@@ -21,7 +21,7 @@ TipTap provides an official extension using [Lowlight](https://github.com/wooorm
 Assuming you have Rhino installed and working, let's start by installing the additional dependencies we need.
 
 ```bash
-yarn add lowlight @tiptap/extension-code-block-lowlight hast-util-to-html
+yarn add lowlight @tiptap/extension-code-block-lowlight hast-util-to-html he
 ```
 
 ## Adding to RhinoEditor


### PR DESCRIPTION
Proposed for your consideration. Two things are addressed in here.

First is a function to strip all hljs-* spans from existing code when editing with rhino. This allows CodeBlockLowlight to then properly re- parse the code blocks for highlighting. Without this, the spans do appear in the editor's highlighted code blocks, but some newlines are missing. The missing newlines will be when they are at the end of a line with only whitespace after them. Those newlines get lost in processing if these spans are not first stripped.

Second is for DB storage, decoding the code content before we re- process it for storage. Without decoding first, some HTML entities will get double-encoded.

I also changed the #highlightCodeblocks function to no longer track highlighting with a has-highlighted HTML attribute. In my testing this was leading to the JS sometimes skipping highlighting upon DB storage. I'm not sure why this tracking existed before, whether it was inadvertent double-execution of this function or if it related to not removing spans before reprocessing edited code, which we now do in #stripHljsSpans. I don't _think_ it's necessary, but I could find out I'm wrong.

I adapted this documentation from our Pika.page code. Apologies for any typos/mistakes!