### PR TITLE
Set ordered lists to have a `decimal` style by default

### DIFF
--- a/src/exports/styles/trix.css
+++ b/src/exports/styles/trix.css
@@ -136,6 +136,10 @@
   list-style: disc;
 }
 
+.trix-content ol {
+  list-style-type: decimal;
+}
+
 .trix-content
   figure[data-trix-attachment].has-focus
   figcaption.is-empty::before {


### PR DESCRIPTION
Small issue we noticed while using rhino in our application with the Trix CSS mixin: Ordered lists were not receiving any styling. 

This small PR fixes that issue by modifying the necessary CSS file.