### PR TITLE
Preserve whitespace for empty paragraph tags and leading empty space

### DIFF
--- a/.changeset/mighty-socks-agree.md
+++ b/.changeset/mighty-socks-agree.md
@@ -2,4 +2,4 @@
 "rhino-editor": patch
 ---
 
-Bug fix: empty <p> tags and whitespace are now handled equivalent to Trix.
+Bug fix: empty `<p>` tags and whitespace are now handled equivalent to Trix.

--- a/.changeset/mighty-socks-agree.md
+++ b/.changeset/mighty-socks-agree.md
@@ -1,0 +1,5 @@
+---
+"rhino-editor": patch
+---
+
+Bug fix: empty <p> tags and whitespace are now handled equivalent to Trix.

--- a/.changeset/small-ears-sit.md
+++ b/.changeset/small-ears-sit.md
@@ -1,0 +1,5 @@
+---
+"rhino-editor": patch
+---
+
+Bug Fix: Fixed a bug in the `getHTMLContentFromRange()` method on `<rhino-editor>`

--- a/src/exports/elements/tip-tap-editor-base.ts
+++ b/src/exports/elements/tip-tap-editor-base.ts
@@ -272,11 +272,13 @@ export class TipTapEditorBase extends BaseElement {
     const fragment = contentSlice.content;
 
     // Serialize the fragment to a DOM fragment
-    const domFragment = DOMSerializer.fromSchema(editor.schema).serializeFragment(fragment);
-    tempScript.append(domFragment)
+    const domFragment = DOMSerializer.fromSchema(
+      editor.schema,
+    ).serializeFragment(fragment);
+    tempScript.append(domFragment);
 
-    replaceSpacesWithNbsp(tempScript)
-    return tempScript.innerHTML
+    replaceSpacesWithNbsp(tempScript);
+    return tempScript.innerHTML;
   }
 
   /**
@@ -474,9 +476,9 @@ export class TipTapEditorBase extends BaseElement {
         this.rebuildEditor();
         this.dispatchEvent(new InitializeEvent());
         this.__initializationResolver__?.();
-        await this.__initializationPromise__
+        await this.__initializationPromise__;
         // This prevents syncing issues when the editor loads content.
-        this.updateInputElementValue()
+        this.updateInputElementValue();
       });
     });
   }
@@ -615,19 +617,18 @@ export class TipTapEditorBase extends BaseElement {
       return JSON.stringify(this.editor.getJSON());
     }
 
-
     const editor = this.editor;
-    return serializeWithNbsp(editor.state.doc, editor.schema)
+    return serializeWithNbsp(editor.state.doc, editor.schema);
   }
 
   /**
    * @override
    * Apparently this is a native dom method?
    */
-  getHTML () {
+  getHTML() {
     if (this.editor == null) return "";
     const editor = this.editor;
-    return serializeWithNbsp(editor.state.doc, editor.schema)
+    return serializeWithNbsp(editor.state.doc, editor.schema);
   }
 
   /**
@@ -863,8 +864,7 @@ export class TipTapEditorBase extends BaseElement {
         el.insertAdjacentText("beforeend", " · ");
       });
 
-
-    doc.querySelectorAll("p > br").forEach((el) => el.remove())
+    doc.querySelectorAll("p > br").forEach((el) => el.remove());
 
     const body = doc.querySelector("body");
 
@@ -987,26 +987,28 @@ export class TipTapEditorBase extends BaseElement {
 
 function serializeWithNbsp(node: Node, schema: Schema) {
   // Create a DOM fragment from the ProseMirror document.
-  const fragment = DOMSerializer.fromSchema(schema).serializeFragment(node.content);
-  const tempDiv = document.createElement('div');
+  const fragment = DOMSerializer.fromSchema(schema).serializeFragment(
+    node.content,
+  );
+  const tempDiv = document.createElement("div");
   tempDiv.appendChild(fragment);
 
-  replaceSpacesWithNbsp(tempDiv)
+  replaceSpacesWithNbsp(tempDiv);
 
   return tempDiv.innerHTML;
 }
 
-function replaceSpacesWithNbsp (htmlElement: Element) {
+function replaceSpacesWithNbsp(htmlElement: Element) {
   // Replace spaces with nbsp; to bypass Nokogiri whitespace stripping.
-  const allNodes = htmlElement.querySelectorAll('*'); // I think this a fine??
-  const allPNodes = htmlElement.querySelectorAll("p")
+  const allNodes = htmlElement.querySelectorAll("*"); // I think this a fine??
+  const allPNodes = htmlElement.querySelectorAll("p");
   allPNodes.forEach((node) => {
     if (node.textContent?.trim() === "") {
       // `<br class='rhino-preserve-line'>` gets stripped, so make it a plain `<br>`
-      node.innerHTML = "<br>" + node.innerHTML
+      node.innerHTML = "<br>" + node.innerHTML;
     }
-  })
-  allNodes.forEach(node => {
-    node.innerHTML = node.innerHTML.replace(/ /g, '&nbsp;');
+  });
+  allNodes.forEach((node) => {
+    node.innerHTML = node.innerHTML.replace(/ /g, "&nbsp;");
   });
 }

--- a/src/exports/elements/tip-tap-editor-base.ts
+++ b/src/exports/elements/tip-tap-editor-base.ts
@@ -38,7 +38,7 @@ import { RhinoBlurEvent } from "../events/rhino-blur-event.js";
 import { RhinoChangeEvent } from "../events/rhino-change-event.js";
 import { SelectionChangeEvent } from "../events/selection-change-event.js";
 import { RhinoPasteEvent } from "../events/rhino-paste-event.js";
-import { DOMSerializer, Slice } from "@tiptap/pm/model";
+import { DOMSerializer, Node, Schema, Slice } from "@tiptap/pm/model";
 import type { EditorView } from "@tiptap/pm/view";
 import { AttachmentRemoveEvent } from "../events/attachment-remove-event.js";
 
@@ -264,25 +264,19 @@ export class TipTapEditorBase extends BaseElement {
       return "";
     }
 
-    const { state } = editor;
-    const htmlArray: string[] = [];
-
     const tempScript = document.createElement("script");
     // We want plain text so we don't parse.
     tempScript.type = "text/plain";
 
-    state.doc.nodesBetween(from, to, (node, _pos, parent) => {
-      if (parent === state.doc) {
-        tempScript.innerHTML = "";
-        const serializer = DOMSerializer.fromSchema(editor.schema);
-        const dom = serializer.serializeNode(node);
-        tempScript.appendChild(dom);
-        htmlArray.push(tempScript.innerHTML);
-        tempScript.innerHTML = "";
-      }
-    });
+    const contentSlice = editor.view.state.doc.slice(from, to);
+    const fragment = contentSlice.content;
 
-    return htmlArray.join("");
+    // Serialize the fragment to a DOM fragment
+    const domFragment = DOMSerializer.fromSchema(editor.schema).serializeFragment(fragment);
+    tempScript.append(domFragment)
+
+    replaceSpacesWithNbsp(tempScript)
+    return tempScript.innerHTML
   }
 
   /**
@@ -480,6 +474,9 @@ export class TipTapEditorBase extends BaseElement {
         this.rebuildEditor();
         this.dispatchEvent(new InitializeEvent());
         this.__initializationResolver__?.();
+        await this.__initializationPromise__
+        // This prevents syncing issues when the editor loads content.
+        this.updateInputElementValue()
       });
     });
   }
@@ -618,7 +615,19 @@ export class TipTapEditorBase extends BaseElement {
       return JSON.stringify(this.editor.getJSON());
     }
 
-    return this.editor.getHTML();
+
+    const editor = this.editor;
+    return serializeWithNbsp(editor.state.doc, editor.schema)
+  }
+
+  /**
+   * @override
+   * Apparently this is a native dom method?
+   */
+  getHTML () {
+    if (this.editor == null) return "";
+    const editor = this.editor;
+    return serializeWithNbsp(editor.state.doc, editor.schema)
   }
 
   /**
@@ -854,6 +863,9 @@ export class TipTapEditorBase extends BaseElement {
         el.insertAdjacentText("beforeend", " · ");
       });
 
+
+    doc.querySelectorAll("p > br").forEach((el) => el.remove())
+
     const body = doc.querySelector("body");
 
     if (body) {
@@ -971,4 +983,30 @@ export class TipTapEditorBase extends BaseElement {
 
     return editor;
   }
+}
+
+function serializeWithNbsp(node: Node, schema: Schema) {
+  // Create a DOM fragment from the ProseMirror document.
+  const fragment = DOMSerializer.fromSchema(schema).serializeFragment(node.content);
+  const tempDiv = document.createElement('div');
+  tempDiv.appendChild(fragment);
+
+  replaceSpacesWithNbsp(tempDiv)
+
+  return tempDiv.innerHTML;
+}
+
+function replaceSpacesWithNbsp (htmlElement: Element) {
+  // Replace spaces with nbsp; to bypass Nokogiri whitespace stripping.
+  const allNodes = htmlElement.querySelectorAll('*'); // I think this a fine??
+  const allPNodes = htmlElement.querySelectorAll("p")
+  allPNodes.forEach((node) => {
+    if (node.textContent?.trim() === "") {
+      // `<br class='rhino-preserve-line'>` gets stripped, so make it a plain `<br>`
+      node.innerHTML = "<br>" + node.innerHTML
+    }
+  })
+  allNodes.forEach(node => {
+    node.innerHTML = node.innerHTML.replace(/ /g, '&nbsp;');
+  });
 }

--- a/src/exports/elements/tip-tap-editor.ts
+++ b/src/exports/elements/tip-tap-editor.ts
@@ -184,7 +184,7 @@ export class TipTapEditor extends TipTapEditorBase {
   /**
    * The heading level to use for the heading button
    */
-  defaultHeadingLevel: 1 | 2 | 3 | 4 | 5 | 6 = 1
+  defaultHeadingLevel: 1 | 2 | 3 | 4 | 5 | 6 = 1;
 
   /**
    * Translations for various aspects of the editor.
@@ -667,11 +667,12 @@ export class TipTapEditor extends TipTapEditorBase {
 
     if (!headingEnabled) return html``;
 
-    const defaultHeadingLevel = this.defaultHeadingLevel || 1
+    const defaultHeadingLevel = this.defaultHeadingLevel || 1;
 
     const isActive = Boolean(this.editor?.isActive("heading"));
     const isDisabled =
-      this.editor == null || !this.editor.can().toggleHeading({ level: defaultHeadingLevel });
+      this.editor == null ||
+      !this.editor.can().toggleHeading({ level: defaultHeadingLevel });
 
     let tooltip_slot_name = "heading-tooltip";
     let tooltip_id = "heading";
@@ -713,7 +714,11 @@ export class TipTapEditor extends TipTapEditorBase {
             return;
           }
 
-          this.editor?.chain().focus().toggleHeading({ level: defaultHeadingLevel }).run();
+          this.editor
+            ?.chain()
+            .focus()
+            .toggleHeading({ level: defaultHeadingLevel })
+            .run();
         }}
       >
         <slot name=${icon_slot_name}>${this.icons.heading}</slot>


### PR DESCRIPTION
I _think_ this problem stems from Nokogiri / Rails HTML Sanitizer.

In fact, in poking at the source, it does say whitespace is not guaranteed.

https://github.com/rails/rails-html-sanitizer/blob/c7ab9f2f52b403dfd7fcfb99c4fe1a42f0a91549/lib/rails/html/sanitizer.rb#L251-L259

so, this change preserves whitespace and line breaks via `nbsp;` and `<br>` respectively to force the parser to respect us ;)

Video of the 3 browsers and the new change:


https://github.com/user-attachments/assets/23fab0c7-e4b4-460d-b69b-5063cfbfc932

